### PR TITLE
VIH-8013 stop TF changes alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Below are some instructions for some of the tests.
 
 ## Testing
 Before starting testing, make sure the client IP(s) for the machines you are testing from is added to the 
-`rtmps_source_address_prefixes` variable. This can be found in a variable group in Azure DevOps called `cvp-<env>`.
+`dev_source_address_prefixes` variable. This can be found in a variable group in Azure DevOps called `cvp-<env>`.
 
 ### Functional tests
 

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ module "wowza" {
   wowza_offer                   = var.wowza_offer
   ssh_public_key                = var.ssh_public_key
   rtmps_source_address_prefixes = var.rtmps_source_address_prefixes
+  dev_source_address_prefixes   = var.dev_source_address_prefixes
   ws_name                       = var.ws_name
   ws_sub_id                     = var.ws_sub_id
   ws_rg                         = var.ws_rg

--- a/modules/wowza/az-monitor-diagnostic-set.tf
+++ b/modules/wowza/az-monitor-diagnostic-set.tf
@@ -45,29 +45,29 @@ resource "azurerm_monitor_diagnostic_setting" "cvp-kv-diag-set" {
 //  }
 // }
 
- resource "azurerm_monitor_diagnostic_setting" "cvp-sa-diag-set" {
-   name                       = "cvp-sa-${var.env}-diag-set"
-   target_resource_id         = azurerm_storage_account.sa.id
-   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.log_analytics.id
- 
-   metric {
-     category = "Capacity"
-     enabled  = true
- 
-     retention_policy {
-       enabled = false
-     }
-   }
-   metric {
- 
-     category = "Transaction"
-     enabled  = true
- 
-     retention_policy {
-       enabled = false
-     }
-   }
- }
+resource "azurerm_monitor_diagnostic_setting" "cvp-sa-diag-set" {
+  name                       = "cvp-sa-${var.env}-diag-set"
+  target_resource_id         = azurerm_storage_account.sa.id
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.log_analytics.id
+
+  metric {
+    category = "Capacity"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+  metric {
+
+    category = "Transaction"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}
 
 resource "azurerm_monitor_diagnostic_setting" "cvp-pipvm1-diag-set" {
   name                       = "cvp-pipvm1-${var.env}-diag-set"

--- a/modules/wowza/main.tf
+++ b/modules/wowza/main.tf
@@ -153,6 +153,7 @@ resource "azurerm_network_security_group" "sg" {
     source_address_prefixes    = var.rtmps_source_address_prefixes
     destination_address_prefix = "*"
   }
+  
   #egress rules
   security_rule {
     name                       = "Required_Packages_443"
@@ -221,6 +222,29 @@ resource "azurerm_network_security_group" "sg" {
     destination_address_prefix = "*"
   }
   tags = var.common_tags
+}
+
+resource "azurerm_network_security_rule" "developer_rule" {
+  name                        = "RTMPS_Dev"
+  priority                    = 1039
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "443"
+  source_address_prefix       = ""
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.sg.name
+
+  depends_on = [
+    azurerm_network_security_group.sg
+  ]
+  lifecycle {
+    ignore_changes = [
+      source_address_prefix
+    ]
+  }
 }
 
 resource "azurerm_network_interface" "nic1" {

--- a/modules/wowza/main.tf
+++ b/modules/wowza/main.tf
@@ -101,7 +101,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "vnet_link" {
   private_dns_zone_name = azurerm_private_dns_zone.blob.name
   virtual_network_id    = azurerm_virtual_network.vnet.id
   registration_enabled  = true
-  tags = var.common_tags
+  tags                  = var.common_tags
 }
 
 resource "azurerm_private_dns_a_record" "sa_a_record" {
@@ -153,7 +153,7 @@ resource "azurerm_network_security_group" "sg" {
     source_address_prefixes    = var.rtmps_source_address_prefixes
     destination_address_prefix = "*"
   }
-  
+
   #egress rules
   security_rule {
     name                       = "Required_Packages_443"
@@ -232,7 +232,7 @@ resource "azurerm_network_security_rule" "developer_rule" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "443"
-  source_address_prefix       = ""
+  source_address_prefix       = var.dev_source_address_prefixes
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.rg.name
   network_security_group_name = azurerm_network_security_group.sg.name

--- a/modules/wowza/variables.tf
+++ b/modules/wowza/variables.tf
@@ -120,6 +120,10 @@ variable "rtmps_source_address_prefixes" {
   type = list(string)
 }
 
+variable "dev_source_address_prefixes" {
+  type = string
+}
+
 variable "ws_name" {
   type = string
 }

--- a/nightly-pipeline.yaml
+++ b/nightly-pipeline.yaml
@@ -182,7 +182,7 @@ stages:
                 resourceGroupName: "${{variables.product}}-recordings-${{variables.env}}-rg"
                 nsgName: "${{variables.product}}-recordings-${{variables.env}}-sg"
                 nsgRuleName: "RTMPS_Dev"
-                sourceAddressPrefixes: "${{ variables.defaultDevIp }}"
+                sourceAddressPrefixes: "${{ variables.dev_source_address_prefixes }}"
 
   - ${{each env in parameters.envs}}:
     - stage: '${{env}}HouseKeeper'

--- a/nightly-pipeline.yaml
+++ b/nightly-pipeline.yaml
@@ -182,6 +182,7 @@ stages:
                 resourceGroupName: "${{variables.product}}-recordings-${{variables.env}}-rg"
                 nsgName: "${{variables.product}}-recordings-${{variables.env}}-sg"
                 nsgRuleName: "RTMPS_Dev"
+                sourceAddressPrefixes: "${{ variables.defaultDevIp }}"
 
   - ${{each env in parameters.envs}}:
     - stage: '${{env}}HouseKeeper'

--- a/nightly-pipeline.yaml
+++ b/nightly-pipeline.yaml
@@ -169,6 +169,20 @@ stages:
                 message: "$(wowzaCheck.msg)"
                 conditionAction: $(wowzaCheck.sendMsg)
 
+        - job: Clean${{env}}
+          displayName: 'Clean ${{env}} down'
+          steps: 
+            - checkout: none
+            - download: none
+            
+            - template: pipeline/steps/az-nsg-update-source.yml
+              parameters: 
+                subscriptionName: ${{variables.subscriptionName}}
+                env: ${{variables.env}}
+                resourceGroupName: "${{variables.product}}-recordings-${{variables.env}}-rg"
+                nsgName: "${{variables.product}}-recordings-${{variables.env}}-sg"
+                nsgRuleName: "RTMPS_Dev"
+
   - ${{each env in parameters.envs}}:
     - stage: '${{env}}HouseKeeper'
       displayName: '${{env}} House Keeper Tasks'

--- a/pipeline/steps/az-nsg-update-source.yml
+++ b/pipeline/steps/az-nsg-update-source.yml
@@ -1,0 +1,29 @@
+parameters:
+  - name: subscriptionName
+    type: string
+  - name: env
+    type: string
+  - name: resourceGroupName
+    type: string
+  - name: nsgName
+    type: string
+  - name: nsgRuleName
+    type: string
+  - name: sourceAddressPrefixes
+    type: string
+    default: ''
+      
+  - task: AzureCLI@2
+    displayName: 'Set Variables'
+    inputs:
+      azureSubscription: '${{ parameters.subscriptionName }}'
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        nsgRule="${{ parameters.nsgRuleName }}"
+        nsgName="${{ parameters.nsgName }}"
+        rgName="${{ parameters.resourceGroupName }}"
+        sourceAddressPrefixes="${{ parameters.sourceAddressPrefixes }}"
+
+        echo "Update $nsgName rule $nsgRule to $sourceAddressPrefixes"
+        az network nsg rule update --name $nsgRule --nsg-name $nsgName --resource-group $rgName --source-address-prefixes $sourceAddressPrefixes

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -142,12 +142,15 @@ steps:
 
         echo "Copy wildcard cert from cftapps"
         az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f cert-cft.pfx
+        cftAppsVersionUrl=$(az keyvault secret show --id https://$sourceKvName.vault.azure.net/secrets/$certName --query "id")
+        cftAppsVersionId=${cftAppsVersionUrl##*/}
+        echo "cftapps Version $cftAppsVersionId"
 
         base64 -d cert-cft.pfx > cert-up.pfx
 
         import(){
             echo "Import the cert to our new KV $kvName"
-            az keyvault certificate import --file cert-up.pfx --vault-name $kvName --name $certName --verbose
+            az keyvault certificate import --file cert-up.pfx --vault-name $kvName --name $certName --tags parentVersion=$cftAppsVersionId --verbose
         }
 
         echo "Check if cert exists"
@@ -158,23 +161,13 @@ steps:
         else
             echo "Cert exists"
             echo "Get Existing cert from CVP"
-            az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert-cvp.pfx
-            base64 -d cert-cvp.pfx > cert-existing.pfx
+            kvSecretVersion=$(az keyvault secret show --id https://$kvName.vault.azure.net/secrets/$certName --query "[?tags.parentVersion == '$cftAppsVersionId'].id")
 
-            openssl base64 -in cert-existing.pfx -out cert-existing.pem
-            openssl base64 -in cert-up.pfx -out cert-up.pem
-            echo ""
-            echo "up"
-            cat cert-up.pem
-            echo ""
-            echo "existing"
-            cat cert-existing.pem
-
-            if cmp -s cert-up.pem cert-existing.pem; then
-                echo "No Change in Cert"
-            else
+            if [ "$kvSecretVersion" = "" ]; then
                 echo "Change Required in Cert"
                 import
+            else
+                echo "No Change in Cert"
             fi
         fi
 

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -161,16 +161,17 @@ steps:
             az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert-cvp.pfx
             base64 -d cert-cvp.pfx > cert-existing.pfx
 
-            openssl pkcs12 -in cert-up.pfx -out cert-up.pem -nodes 
-            openssl pkcs12 -in cert-existing.pfx -out cert-existing.pem -nodes 
+            openssl base64 -in cert-existing.pfx -out cert-existing.pem
+            openssl base64 -in cert-up.pfx -out cert-up.pem
             echo ""
             echo "up"
-            cat cert-up.pem
+            cat cert-up.pfx
             echo ""
             echo "existing"
-            cat cert-existing.pem
+            cat cert-existing.pfx
+            openssl base64 -in <infile> -out <outfile>
 
-            if cmp -s cert-up.pem cert-existing.pem; then
+            if cmp -s cert-up.pfx cert-existing.pfx; then
                 echo "No Change in Cert"
             else
                 echo "Change Required in Cert"

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -150,21 +150,22 @@ steps:
             az keyvault certificate import --file cert-up.pfx --vault-name $kvName --name $certName --verbose
         }
 
-        if [ $kvSecret = "" ]; then
+        echo "Check if cert exists"
+        kvSecret=$(az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName --query "id")
+        if [ "$kvSecret" = "" ]; then
             echo "Cert doesn't exist"
-            import() 
-        fi
-        if [ $kvSecret != "" ]; then
+            import
+        else
             echo "Cert exists"
             echo "Get Existing cert from CVP"
             az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert.pfx
             base64 -d cert.pfx > cert-existing.pfx
 
-            if cmp -s "cert-up.pfx" "cert-existing.pfx"; then
+            if cmp -s cert-up.pfx cert-existing.pfx; then
                 echo "No Change in Cert"
             else
                 echo "Change Required in Cert"
-                import()
+                import
             fi
         fi
 

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -142,7 +142,7 @@ steps:
 
         echo "Copy wildcard cert from cftapps"
         az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f cert-cft.pfx
-        cftAppsVersionUrl=$(az keyvault secret show --id https://$sourceKvName.vault.azure.net/secrets/$certName --query "id")
+        cftAppsVersionUrl=$(az keyvault secret show --id https://$sourceKvName.vault.azure.net/secrets/$certName --query "id" -o tsv)
         cftAppsVersionId=${cftAppsVersionUrl##*/}
         echo "cftapps Version $cftAppsVersionId"
 

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -165,13 +165,12 @@ steps:
             openssl base64 -in cert-up.pfx -out cert-up.pem
             echo ""
             echo "up"
-            cat cert-up.pfx
+            cat cert-up.pem
             echo ""
             echo "existing"
-            cat cert-existing.pfx
-            openssl base64 -in <infile> -out <outfile>
+            cat cert-existing.pem
 
-            if cmp -s cert-up.pfx cert-existing.pfx; then
+            if cmp -s cert-up.pem cert-existing.pem; then
                 echo "No Change in Cert"
             else
                 echo "Change Required in Cert"

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -151,7 +151,7 @@ steps:
         }
 
         echo "Check if cert exists"
-        $kvSecret=$(az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName --query "id")
+        kvSecret=$(az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName --query "id")
         if [ "$kvSecret" = "" ]; then
             echo "Cert doesn't exist"
             import()

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -141,15 +141,15 @@ steps:
         echo "Logged in as oid $oid"
 
         cd $(System.DefaultWorkingDirectory)
-        
-        echo "Copy wildcard cert from cftapps"
-        az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f cert-cft.pfx
 
-        base64 -d cert-cft.pfx > cert-up.pfx
+        echo "Copy wildcard cert from cftapps"
+        az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f $(System.DefaultWorkingDirectory)/cert-cft.pfx
+
+        base64 -d $(System.DefaultWorkingDirectory)/cert-cft.pfx > $(System.DefaultWorkingDirectory)/cert-up.pfx
 
         import(){
             echo "Import the cert to our new KV $kvName"
-            az keyvault certificate import --file cert-up.pfx --vault-name $kvName --name $certName --verbose
+            az keyvault certificate import --file $(System.DefaultWorkingDirectory)/cert-up.pfx --vault-name $kvName --name $certName --verbose
         }
 
         echo "Check if cert exists"
@@ -160,10 +160,10 @@ steps:
         else
             echo "Cert exists"
             echo "Get Existing cert from CVP"
-            az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert-cvp.pfx
-            base64 -d cert-cvp.pfx > cert-existing.pfx
+            az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f $(System.DefaultWorkingDirectory)/cert-cvp.pfx
+            base64 -d $(System.DefaultWorkingDirectory)/cert-cvp.pfx > $(System.DefaultWorkingDirectory)/cert-existing.pfx
 
-            if cmp -s cert-up.pfx cert-existing.pfx; then
+            if cmp -s $(System.DefaultWorkingDirectory)/cert-up.pfx $(System.DefaultWorkingDirectory)/cert-existing.pfx; then
                 echo "No Change in Cert"
             else
                 echo "Change Required in Cert"

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -134,22 +134,47 @@ steps:
       inlineScript: |
         kvName="$(kvName)"
         oid=$(oid)
+        env="${{ parameters.env }}"
+        certName="${{ parameters.certName }}"
+        kvNamePrefix="$(kv_name_prefix)"
+        sourceKvName="$kvNamePrefix-$env"
         echo "Logged in as oid $oid"
 
         echo "Copy wildcard cert from cftapps"
-        az keyvault secret download --id https://$(kv_name_prefix)-${{ parameters.env }}.vault.azure.net/secrets/${{ parameters.certName }} -f cert.pfx
+        az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f cert.pfx
 
         base64 -d cert.pfx > cert-up.pfx
 
-        echo "Import the cert to our new KV $kvName"
-        az keyvault certificate import --file cert-up.pfx --vault-name $kvName --name ${{ parameters.certName }} --verbose
+        import(){
+            echo "Import the cert to our new KV $kvName"
+            az keyvault certificate import --file cert-up.pfx --vault-name $kvName --name $certName --verbose
+        }
+
+        echo "Check if cert exists"
+        $kvSecret=$(az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName --query "id")
+        if [ $kvSecret = "" ]; then
+            echo "Cert doesn't exist"
+            import()
+        else
+            echo "Cert exists"
+            echo "Get Existing cert from CVP"
+            az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert.pfx
+            base64 -d cert.pfx > cert-existing.pfx
+
+            if cmp -s cert-up.pfx cert-existing.pfx; then
+                echo "No Change in Cert"
+            else
+                echo "Change Required in Cert"
+                import()
+            fi
+        fi
 
         echo "Download the cert as a pem file"
-        az keyvault certificate download --id https://$kvName.vault.azure.net/certificates/${{ parameters.certName }} -f cert.pem
+        az keyvault certificate download --id https://$kvName.vault.azure.net/certificates/$certName -f cert.pem
         certPath=`pwd`/cert.pem
 
         echo "Capture cert thumbprint and secret resource id"
-        cert=$(az keyvault certificate show --id https://$kvName.vault.azure.net/certificates/${{ parameters.certName }})
+        cert=$(az keyvault certificate show --id https://$kvName.vault.azure.net/certificates/$certName)
         thumbprint=$(echo $cert | jq .x509ThumbprintHex)
         secretId=$(echo $cert | jq .sid)
 

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -152,7 +152,7 @@ steps:
 
         echo "Check if cert exists"
         $kvSecret=$(az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName --query "id")
-        if [ $kvSecret = "" ]; then
+        if [ "$kvSecret" = "" ]; then
             echo "Cert doesn't exist"
             import()
         else

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -161,14 +161,16 @@ steps:
             az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert-cvp.pfx
             base64 -d cert-cvp.pfx > cert-existing.pfx
 
+            openssl pkcs12 -in cert-up.pfx -out cert-up.pem -nodes 
+            openssl pkcs12 -in cert-existing.pfx -out cert-existing.pem -nodes 
             echo ""
             echo "up"
-            cat cert-up.pfx
+            cat cert-up.pem
             echo ""
             echo "existing"
-            cat cert-existing.pfx
+            cat cert-existing.pem
 
-            if cmp -s cert-up.pfx cert-existing.pfx; then
+            if cmp -s cert-up.pem cert-existing.pem; then
                 echo "No Change in Cert"
             else
                 echo "Change Required in Cert"

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -150,18 +150,17 @@ steps:
             az keyvault certificate import --file cert-up.pfx --vault-name $kvName --name $certName --verbose
         }
 
-        echo "Check if cert exists"
-        kvSecret=$(az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName --query "id")
-        if [ "$kvSecret" = "" ]; then
+        if [ $kvSecret = "" ]; then
             echo "Cert doesn't exist"
-            import()
-        else
+            import() 
+        fi
+        if [ $kvSecret != "" ]; then
             echo "Cert exists"
             echo "Get Existing cert from CVP"
             az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert.pfx
             base64 -d cert.pfx > cert-existing.pfx
 
-            if cmp -s cert-up.pfx cert-existing.pfx; then
+            if cmp -s "cert-up.pfx" "cert-existing.pfx"; then
                 echo "No Change in Cert"
             else
                 echo "Change Required in Cert"

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -161,7 +161,7 @@ steps:
         else
             echo "Cert exists"
             echo "Get Existing cert from CVP"
-            kvSecretVersion=$(az keyvault secret show --id https://$kvName.vault.azure.net/secrets/$certName  --query "tags.parentVersion" -o tsv")
+            kvSecretVersion=$(az keyvault secret show --id https://$kvName.vault.azure.net/secrets/$certName  --query "tags.parentVersion" -o tsv)
 
             if [ "$kvSecretVersion" != "$cftAppsVersionId" ]; then
                 echo "Change Required in Cert"

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -151,7 +151,7 @@ steps:
         }
 
         echo "Check if cert exists"
-        kvSecret=$(az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName --query "id")
+        kvSecret=$(az keyvault secret show --id https://$kvName.vault.azure.net/secrets/$certName --query "id")
         if [ "$kvSecret" = "" ]; then
             echo "Cert doesn't exist"
             import

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -141,9 +141,9 @@ steps:
         echo "Logged in as oid $oid"
 
         echo "Copy wildcard cert from cftapps"
-        az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f cert.pfx
+        az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f cert-cft.pfx
 
-        base64 -d cert.pfx > cert-up.pfx
+        base64 -d cert-cft.pfx > cert-up.pfx
 
         import(){
             echo "Import the cert to our new KV $kvName"
@@ -158,8 +158,8 @@ steps:
         else
             echo "Cert exists"
             echo "Get Existing cert from CVP"
-            az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert.pfx
-            base64 -d cert.pfx > cert-existing.pfx
+            az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert-cvp.pfx
+            base64 -d cert-cvp.pfx > cert-existing.pfx
 
             if cmp -s cert-up.pfx cert-existing.pfx; then
                 echo "No Change in Cert"

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -131,7 +131,6 @@ steps:
       azureSubscription: '${{ parameters.subscriptionName }}'
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
-      workingDirectory: $(System.DefaultWorkingDirectory)
       inlineScript: |
         kvName="$(kvName)"
         oid=$(oid)
@@ -141,6 +140,8 @@ steps:
         sourceKvName="$kvNamePrefix-$env"
         echo "Logged in as oid $oid"
 
+        cd $(System.DefaultWorkingDirectory)
+        
         echo "Copy wildcard cert from cftapps"
         az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f cert-cft.pfx
 

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -161,9 +161,9 @@ steps:
         else
             echo "Cert exists"
             echo "Get Existing cert from CVP"
-            kvSecretVersion=$(az keyvault secret show --id https://$kvName.vault.azure.net/secrets/$certName --query "[?tags.parentVersion == '$cftAppsVersionId'].id")
+            kvSecretVersion=$(az keyvault secret show --id https://$kvName.vault.azure.net/secrets/$certName  --query "tags.parentVersion" -o tsv")
 
-            if [ "$kvSecretVersion" = "" ]; then
+            if [ "$kvSecretVersion" != "$cftAppsVersionId" ]; then
                 echo "Change Required in Cert"
                 import
             else

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -140,16 +140,14 @@ steps:
         sourceKvName="$kvNamePrefix-$env"
         echo "Logged in as oid $oid"
 
-        cd $(System.DefaultWorkingDirectory)
-
         echo "Copy wildcard cert from cftapps"
-        az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f $(System.DefaultWorkingDirectory)/cert-cft.pfx
+        az keyvault secret download --id https://$sourceKvName.vault.azure.net/secrets/$certName -f cert-cft.pfx
 
-        base64 -d $(System.DefaultWorkingDirectory)/cert-cft.pfx > $(System.DefaultWorkingDirectory)/cert-up.pfx
+        base64 -d cert-cft.pfx > cert-up.pfx
 
         import(){
             echo "Import the cert to our new KV $kvName"
-            az keyvault certificate import --file $(System.DefaultWorkingDirectory)/cert-up.pfx --vault-name $kvName --name $certName --verbose
+            az keyvault certificate import --file cert-up.pfx --vault-name $kvName --name $certName --verbose
         }
 
         echo "Check if cert exists"
@@ -160,10 +158,17 @@ steps:
         else
             echo "Cert exists"
             echo "Get Existing cert from CVP"
-            az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f $(System.DefaultWorkingDirectory)/cert-cvp.pfx
-            base64 -d $(System.DefaultWorkingDirectory)/cert-cvp.pfx > $(System.DefaultWorkingDirectory)/cert-existing.pfx
+            az keyvault secret download --id https://$kvName.vault.azure.net/secrets/$certName -f cert-cvp.pfx
+            base64 -d cert-cvp.pfx > cert-existing.pfx
 
-            if cmp -s $(System.DefaultWorkingDirectory)/cert-up.pfx $(System.DefaultWorkingDirectory)/cert-existing.pfx; then
+            echo ""
+            echo "up"
+            cat cert-up.pfx
+            echo ""
+            echo "existing"
+            cat cert-existing.pfx
+
+            if cmp -s cert-up.pfx cert-existing.pfx; then
                 echo "No Change in Cert"
             else
                 echo "Change Required in Cert"

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -182,6 +182,13 @@ steps:
         echo "##vso[task.setvariable variable=secretId]$secretId"
         echo "##vso[task.setvariable variable=thumbprint]$thumbprint"
   
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(System.DefaultWorkingDirectory)/*.pfx  # Required  # The folder or file path to publish. This can be a fully-qualified path or a path relative to the root of the repository. Wildcards are not supported. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) are supported. Example: $(Build.ArtifactStagingDirectory)
+      ArtifactName: certs  # Required  # The name of the artifact to create in the publish location.
+      ArtifactType: Container # Options: 'Container', 'FilePath' # Required  # Choose whether to store the artifact in Azure Pipelines, or to copy it to a file share that must be accessible from the build agent.
+
+
   - task: AzureCLI@2
     displayName: 'Create SSH Credentials'
     inputs:

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -160,8 +160,8 @@ steps:
             import
         else
             echo "Cert exists"
-            echo "Get Existing cert from CVP"
             kvSecretVersion=$(az keyvault secret show --id https://$kvName.vault.azure.net/secrets/$certName  --query "tags.parentVersion" -o tsv)
+            echo "Current CVP Version $kvSecretVersion"
 
             if [ "$kvSecretVersion" != "$cftAppsVersionId" ]; then
                 echo "Change Required in Cert"
@@ -183,13 +183,6 @@ steps:
         echo "##vso[task.setvariable variable=certPath]$certPath"
         echo "##vso[task.setvariable variable=secretId]$secretId"
         echo "##vso[task.setvariable variable=thumbprint]$thumbprint"
-  
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(System.DefaultWorkingDirectory)/*.pfx  # Required  # The folder or file path to publish. This can be a fully-qualified path or a path relative to the root of the repository. Wildcards are not supported. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) are supported. Example: $(Build.ArtifactStagingDirectory)
-      ArtifactName: certs  # Required  # The name of the artifact to create in the publish location.
-      ArtifactType: Container # Options: 'Container', 'FilePath' # Required  # Choose whether to store the artifact in Azure Pipelines, or to copy it to a file share that must be accessible from the build agent.
-
 
   - task: AzureCLI@2
     displayName: 'Create SSH Credentials'

--- a/pipeline/steps/az-shared-config.yml
+++ b/pipeline/steps/az-shared-config.yml
@@ -131,6 +131,7 @@ steps:
       azureSubscription: '${{ parameters.subscriptionName }}'
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
+      workingDirectory: $(System.DefaultWorkingDirectory)
       inlineScript: |
         kvName="$(kvName)"
         oid=$(oid)

--- a/pipeline/steps/tf-plan.yaml
+++ b/pipeline/steps/tf-plan.yaml
@@ -67,6 +67,7 @@ steps:
         -var "lb_IPaddress=$(lb_IPaddress)"
         -var "ssh_public_key=$(pubKey)"
         -var "rtmps_source_address_prefixes=[$(rtmps_source_address_prefixes)]"
+        -var "dev_source_address_prefixes=$(dev_source_address_prefixes)"
         -var "ws_name=$(ws_name)"
         -var "ws_rg=$(ws_rg)"
         -var "ws_sub_id=$(ws_sub_id)"

--- a/pipeline/variables/variables-common.yaml
+++ b/pipeline/variables/variables-common.yaml
@@ -8,4 +8,4 @@ variables:
   product: 'cvp'
   businessArea: 'Cross-Cutting'
   application: 'Cloud Video Platform'
-  defaultDevIp: '127.0.0.1'
+  dev_source_address_prefixes: '127.0.0.1'

--- a/pipeline/variables/variables-common.yaml
+++ b/pipeline/variables/variables-common.yaml
@@ -8,3 +8,4 @@ variables:
   product: 'cvp'
   businessArea: 'Cross-Cutting'
   application: 'Cloud Video Platform'
+  defaultDevIp: '127.0.0.1'

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,10 @@ variable "rtmps_source_address_prefixes" {
   type = list(string)
 }
 
+variable "dev_source_address_prefixes" {
+  type = string
+}
+
 variable "ws_name" {
   type = string
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8013


### Change description ###
We now check if we already have a cert in the cvp KV. If we don't then import the downloaded cert.
If we do then it will get the existing one and check if there is any difference. If not then it will just get the details.
If there is then it will import the downloaded cert and then get the details.

TF keeps detecting check in the NSG rule as we add our IPs for dev work.
Created a new NSG Rule for developers IPs which the source is ignored during deployment.
Therefore we can continue what we do without it detecting changes.

Added a process to clean the developer IPs from the new NSG rule to make sure we are secure and not leaving them in.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
