### PR TITLE
VH-8515 Updated agent pool in nightly pipeline

### DIFF
--- a/nightly-pipeline.yaml
+++ b/nightly-pipeline.yaml
@@ -46,6 +46,8 @@ stages:
     jobs:
       - job: GetScheduleName
         displayName: 'Get Schedule Name'
+        pool:
+          vmImage: ubuntu-latest
         steps: 
           - download: none
           - checkout: none


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8515


### Change description ###
Makes the nightly pipeline use the latest Ubunutu version for it's agent. Was previously trying to use Ubuntu 16 (https://developercommunity.visualstudio.com/t/Pipelines-without-a-pool-specified-are-f/1557841)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
