### PR TITLE
VH-8515 Updated agent pools in nightly pipeline

### DIFF
--- a/nightly-pipeline.yaml
+++ b/nightly-pipeline.yaml
@@ -41,6 +41,8 @@ stages:
   - stage: 'GetDependencies'
     displayName: 'Get Dependency Details'
     dependsOn: []
+    pool:
+      vmImage: ubuntu-latest
     variables:
       - group: cvp-common
     jobs:
@@ -71,6 +73,8 @@ stages:
     - stage: 'Validate${{env}}'
       displayName: 'Validate ${{env}}'
       dependsOn: 'Plan${{env}}'
+      pool:
+        vmImage: ubuntu-latest
       variables:
         - template: pipeline/variables/variables-common.yaml
         - template: pipeline/variables/variables-${{env}}.yaml
@@ -239,6 +243,8 @@ stages:
     - stage: '${{env}}HouseKeeper'
       displayName: '${{env}} House Keeper Tasks'
       condition: eq(dependencies.GetDependencies.outputs['GetScheduleName.buildDetail.scheduleName'], 'Monthly' )
+      pool:
+        vmImage: ubuntu-latest
       dependsOn: GetDependencies
       variables:
         - template: pipeline/variables/variables-common.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-8515


### Change description ###
Makes the nightly pipeline use the latest Ubunutu version for it's agent. Was previously trying to use Ubuntu 16 (https://developercommunity.visualstudio.com/t/Pipelines-without-a-pool-specified-are-f/1557841)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
