### PR TITLE
VIH-9719 Move shutdown var to runtime param

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -17,6 +17,14 @@ parameters:
     type: object
     values: []
     default: ['sbox','stg','prod']
+  - name: shutdown_sbox
+    displayName: Shutdown SBOX after tests
+    type: boolean
+    default: true
+  - name: shutdown_stg
+    displayName: Shutdown STG after tests
+    type: boolean
+    default: true
 
 variables:
   - template: ./pipeline/variables/variables-common.yaml
@@ -42,7 +50,7 @@ stages:
     - template: pipeline/stages/deploy.yaml
       parameters:
         env: ${{env}}
-        ${{ if and(eq(env, 'prod'), contains(lower(variables['Build.SourceBranch']), lower(variables.release_branch_prefix))) }}:  # prod + not release
+        ${{ if and(eq(env, 'prod'), contains(lower(variables['Build.SourceBranch']), lower(variables.release_branch_prefix))) }}:  # prod + is release
           runStage: 'true' 
         ${{ if and(ne(env, 'prod'), eq(contains(lower(variables['Build.SourceBranch']), lower(variables.release_branch_prefix)), False )) }}: # not prod + not release
           runStage: 'true'
@@ -50,6 +58,8 @@ stages:
     - template: pipeline/stages/test.yaml
       parameters:
         env: ${{env}}
+        shutdown_sbox: ${{parameters.shutdown_sbox}}
+        shutdown_stg: ${{parameters.shutdown_stg}}
         ${{ if and(eq(env, 'prod'), contains(lower(variables['Build.SourceBranch']), lower(variables.release_branch_prefix))) }}:  # prod + release
           runStage: 'true' 
         ${{ if and(ne(env, 'prod'), eq(contains(lower(variables['Build.SourceBranch']), lower(variables.release_branch_prefix)), False )) }}: # not prod + not release

--- a/pipeline/stages/test.yaml
+++ b/pipeline/stages/test.yaml
@@ -5,6 +5,12 @@ parameters:
   - name: runStage
     type: string
     default: 'false'
+  - name: shutdown_sbox
+    type: boolean
+    default: true
+  - name: shutdown_stg
+    type: boolean
+    default: true
 
 stages:
   - ${{ if eq(parameters.runStage, true)}}:
@@ -141,7 +147,7 @@ stages:
                   subscriptionName: ${{ variables.subscriptionName }}
                   env: ${{ variables.env }}
 
-        - ${{ if eq(variables.TURN_OFF_VM_POST_RUN, true) }}:
+        - ${{ if or( and( eq(parameters.env, 'sbox'), eq(parameters.shutdown_sbox, true)), and( eq(parameters.env, 'stg'), eq(parameters.shutdown_stg, true)))}}:
           - job: 'StopVM${{parameters.env}}'
             displayName: '${{parameters.env}} Turning Vm off'
             dependsOn: [LoadBalancerTest, VirtualMachineTest]

--- a/pipeline/variables/variables-prod.yaml
+++ b/pipeline/variables/variables-prod.yaml
@@ -11,5 +11,4 @@ variables:
   ws_rg: "oms-automation"
   dynatrace_host_group: "PROD_DTS_CVP"
   dynatrace_tenant_id: "ebe20728"
-  TURN_OFF_VM_POST_RUN: false 
   

--- a/pipeline/variables/variables-sbox.yaml
+++ b/pipeline/variables/variables-sbox.yaml
@@ -11,4 +11,3 @@ variables:
   ws_rg: "oms-automation"
   dynatrace_host_group: "SBOX_DTS_CVP"
   dynatrace_tenant_id: "yrk32651"
-  TURN_OFF_VM_POST_RUN: true 

--- a/pipeline/variables/variables-stg.yaml
+++ b/pipeline/variables/variables-stg.yaml
@@ -11,4 +11,3 @@ variables:
   ws_rg: "oms-automation"
   dynatrace_host_group: "AAT_DTS_CVP"
   dynatrace_tenant_id: "yrk32651"
-  TURN_OFF_VM_POST_RUN: true 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[VIH-9719](https://tools.hmcts.net/jira/browse/VIH-9719)

### Change description ###

Currently, you require a code change if you want to leave either SBOX or STG up and running after tests. This change moves the logic out of the variable file and makes them settable as runtime variables:

`shutdown_sbox`
`shutdown_stg`

These default to `true` but can be unselected if needed. I have created a param for each env to make it easy to see what has been set.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
