### PR TITLE
VIH-11247 add route table and routes to wowza subnet

### DIFF
--- a/terraform/_variables.tf
+++ b/terraform/_variables.tf
@@ -177,6 +177,11 @@ variable "dev_source_address_prefixes" {
   type = string
 }
 
+variable "route_table" {
+  description = "Route Table routes"
+  type        = list(map(string))
+}
+
 #---------------------------------------------------
 # SAS 
 #---------------------------------------------------

--- a/terraform/envs/prod.tfvars
+++ b/terraform/envs/prod.tfvars
@@ -35,3 +35,23 @@ schedules = [
     week_days = ["Monday"]
   }
 ]
+route_table = [
+  {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
+    name                   = "azure_control_plane"
+    address_prefix         = "51.145.56.125/32"
+    next_hop_type          = "Internet"
+    next_hop_in_ip_address = null
+  },
+  {
+    name                   = "soc-prod-vnet"
+    address_prefix         = "10.146.0.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
+  }
+]

--- a/terraform/envs/sbox.tfvars
+++ b/terraform/envs/sbox.tfvars
@@ -28,3 +28,17 @@ schedules = [
     start_vm  = false
   },
 ]
+route_table = [
+  {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "azure_control_plane"
+    address_prefix         = "51.145.56.125/32"
+    next_hop_type          = "Internet"
+    next_hop_in_ip_address = null
+  }
+]

--- a/terraform/envs/stg.tfvars
+++ b/terraform/envs/stg.tfvars
@@ -28,3 +28,23 @@ schedules = [
     start_vm  = false
   },
 ]
+route_table = [
+  {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
+    name                   = "azure_control_plane"
+    address_prefix         = "51.145.56.125/32"
+    next_hop_type          = "Internet"
+    next_hop_in_ip_address = null
+  },
+  {
+    name                   = "soc-prod-vnet"
+    address_prefix         = "10.146.0.0/21"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
+  }
+]

--- a/terraform/route-table.tf
+++ b/terraform/route-table.tf
@@ -1,0 +1,21 @@
+resource "azurerm_route_table" "wowza" {
+  name                = "${local.service_name}-route-table"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tags                = module.ctags.common_tags
+
+  dynamic "route" {
+    for_each = var.route_table
+    content {
+      name                   = route.value.name
+      address_prefix         = route.value.address_prefix
+      next_hop_type          = route.value.next_hop_type
+      next_hop_in_ip_address = route.value.next_hop_in_ip_address
+    }
+  }
+}
+
+resource "azurerm_subnet_route_table_association" "wowza" {
+  subnet_id      = azurerm_subnet.sn.id
+  route_table_id = azurerm_route_table.wowza.id
+}


### PR DESCRIPTION
### Jira link
See [VIH-11247](https://tools.hmcts.net/jira/browse/VIH-11247)

### Change description

Adds a route table to the Wowza subnet, to force all egress traffic via the Palo Alto hubs.

### Testing done

Change tested in Sbox and Stg environments, by creating a file in the mounted path on the Wowza VMs and verifying that the file appears in the corresponding storage account.

### Checklist

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
