### PR TITLE
Update vNet router to pin traffic to palo vm0

### DIFF
--- a/terraform/envs/stg.tfvars
+++ b/terraform/envs/stg.tfvars
@@ -31,7 +31,7 @@ route_table = [
     name                   = "default"
     address_prefix         = "0.0.0.0/0"
     next_hop_type          = "VirtualAppliance"
-    next_hop_in_ip_address = "10.11.72.36"
+    next_hop_in_ip_address = "10.11.72.37"
   },
   {
     name                   = "azure_control_plane"


### PR DESCRIPTION
### Jira link

See [DTSPO-29682](https://tools.hmcts.net/jira/browse/DTSPO-29682)

### Change description

Investigating a possible solution to asymmetric routing problem by pinning all the CVP Recording traffic to a single Palo Alto firewall.

### Testing done

None, simple configuration file change, which will be verified by the pipeline.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
